### PR TITLE
Add option to filter an object before activating the system on it

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -3,8 +3,9 @@
 
 var BehaviorSystem = require('behavior-system')
 
-var plugin = function (game, parent) {
+var plugin = function (game, parent, config) {
   Phaser.Plugin.call(this, game, parent)
+  this._config = config || {};
   this._system = new BehaviorSystem()
 }
 
@@ -13,11 +14,15 @@ plugin.VERSION = '0.1.0'
 plugin.prototype = Object.create(Phaser.Plugin)
 
 plugin.prototype.enable = function (gameObject) {
-  this._system.enable(gameObject)
-  // disable the system if the game object is destroyed
-  if (gameObject.events && gameObject.events.onDestroy) {
-    gameObject.events.onDestroy.add(onDestroyCallback, this._system)
+  if (this._config.filter && this._config.filter(gameObject) === true) {
+    this._system.enable(gameObject)
+    // disable the system if the game object is destroyed
+    if (gameObject.events && gameObject.events.onDestroy) {
+      gameObject.events.onDestroy.add(onDestroyCallback, this._system)
+    }
+    return true
   }
+  return false
 }
 
 plugin.prototype.disable = function (gameObject) {


### PR DESCRIPTION
Exemple:
```js
// just enable if the object (sprite, image, etc) is added to the game world.
var behaviorPlugin = game.plugins.add(Phaser.Plugin.Behavior, {
    filter: function (object) { return object.game.world.constains(object) } 
})

var o1 = game.add.sprite(game.add.sprite(90, 100, 'player'));
behaviorPlugin.enable(o1); // => true (enabled)

var o1 = game.make.sprite(game.add.sprite(90, 100, 'player'));
behaviorPlugin.enable(o2); // => false (not enabled)
```